### PR TITLE
nix: fix "common.sh: line 94: unshare: command not found"

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -9,7 +9,7 @@ let
 
 common =
   { lib, stdenv, fetchpatch, perl, curl, bzip2, sqlite, openssl ? null, xz
-  , bash, coreutils, gzip, gnutar
+  , bash, coreutils, utillinux, gzip, gnutar
   , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline, nlohmann_json
   , autoreconfHook, autoconf-archive, bison, flex
   , jq, libarchive
@@ -40,7 +40,7 @@ common =
       outputs = [ "out" "dev" "man" "doc" ];
 
       nativeBuildInputs =
-        [ pkgconfig ]
+        [ pkgconfig utillinux ]
         ++ lib.optionals is30
           [ autoreconfHook
             autoconf-archive


### PR DESCRIPTION
See
https://github.com/NixOS/nixpkgs/pull/111871#issuecomment-773351871
https://github.com/NixOS/nixpkgs/pull/95742#issuecomment-675472428
https://github.com/NixOS/nixpkgs/issues/56106#issuecomment-492375471